### PR TITLE
Add Classfile Size to DB

### DIFF
--- a/common/src/main/java/de/jd/ecosystems/dto/ClassDiffDTO.java
+++ b/common/src/main/java/de/jd/ecosystems/dto/ClassDiffDTO.java
@@ -4,14 +4,16 @@ public class ClassDiffDTO {
     private Long id;
     private String fqn;
     private String sha512;
+    private long sizeBytes;
 
     public ClassDiffDTO() {
     }
 
-    public ClassDiffDTO(Long id, String fqn, String sha512) {
+    public ClassDiffDTO(Long id, String fqn, String sha512, long sizeBytes) {
         this.id = id;
         this.fqn = fqn;
         this.sha512 = sha512;
+        this.sizeBytes = sizeBytes;
     }
 
     public Long getId() {
@@ -36,5 +38,13 @@ public class ClassDiffDTO {
 
     public void setSha512(String sha512) {
         this.sha512 = sha512;
+    }
+
+    public long getSizeBytes() {
+        return sizeBytes;
+    }
+
+    public void setSizeBytes(long sizeBytes) {
+        this.sizeBytes = sizeBytes;
     }
 }

--- a/common/src/main/java/de/jd/ecosystems/dto/ReleaseDiffDTO.java
+++ b/common/src/main/java/de/jd/ecosystems/dto/ReleaseDiffDTO.java
@@ -6,9 +6,13 @@ public class ReleaseDiffDTO {
     private String version;
     private String previousVersion;
     private int totalClasses;
+    private long totalSizeBytes;
     private List<ClassDiffDTO> added;
+    private long addedSizeBytes;
     private List<ClassDiffDTO> removed;
+    private long removedSizeBytes;
     private List<ClassDiffDTO> modified;
+    private long modifiedSizeBytes;
 
     public ReleaseDiffDTO() {
     }
@@ -37,12 +41,28 @@ public class ReleaseDiffDTO {
         this.totalClasses = totalClasses;
     }
 
+    public long getTotalSizeBytes() {
+        return totalSizeBytes;
+    }
+
+    public void setTotalSizeBytes(long totalSizeBytes) {
+        this.totalSizeBytes = totalSizeBytes;
+    }
+
     public List<ClassDiffDTO> getAdded() {
         return added;
     }
 
     public void setAdded(List<ClassDiffDTO> added) {
         this.added = added;
+    }
+
+    public long getAddedSizeBytes() {
+        return addedSizeBytes;
+    }
+
+    public void setAddedSizeBytes(long addedSizeBytes) {
+        this.addedSizeBytes = addedSizeBytes;
     }
 
     public List<ClassDiffDTO> getRemoved() {
@@ -53,11 +73,27 @@ public class ReleaseDiffDTO {
         this.removed = removed;
     }
 
+    public long getRemovedSizeBytes() {
+        return removedSizeBytes;
+    }
+
+    public void setRemovedSizeBytes(long removedSizeBytes) {
+        this.removedSizeBytes = removedSizeBytes;
+    }
+
     public List<ClassDiffDTO> getModified() {
         return modified;
     }
 
     public void setModified(List<ClassDiffDTO> modified) {
         this.modified = modified;
+    }
+
+    public long getModifiedSizeBytes() {
+        return modifiedSizeBytes;
+    }
+
+    public void setModifiedSizeBytes(long modifiedSizeBytes) {
+        this.modifiedSizeBytes = modifiedSizeBytes;
     }
 }

--- a/common/src/main/java/de/jd/ecosystems/model/ClassFile.java
+++ b/common/src/main/java/de/jd/ecosystems/model/ClassFile.java
@@ -6,12 +6,16 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import jakarta.persistence.Column;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.List;
 
 @Entity
-@Table(name = "class_file")
+@Table(
+    name = "class_file",
+    uniqueConstraints = @UniqueConstraint(name = "uq_class_file_fqn_sha512", columnNames = {"fqn", "sha512"})
+)
 public class ClassFile {
 
     @Id
@@ -23,6 +27,9 @@ public class ClassFile {
 
     @Column(nullable = false, length = 128)
     private String sha512;
+
+    @Column(name = "size_bytes", nullable = false)
+    private long sizeBytes;
 
     @JsonIgnore
     @ManyToMany(mappedBy = "classFiles")
@@ -53,6 +60,14 @@ public class ClassFile {
 
     public void setSha512(String sha512) {
         this.sha512 = sha512;
+    }
+
+    public long getSizeBytes() {
+        return sizeBytes;
+    }
+
+    public void setSizeBytes(long sizeBytes) {
+        this.sizeBytes = sizeBytes;
     }
 
     public List<Release> getReleases() {

--- a/common/src/main/java/de/jd/ecosystems/model/ClassFile.java
+++ b/common/src/main/java/de/jd/ecosystems/model/ClassFile.java
@@ -14,7 +14,8 @@ import java.util.List;
 @Entity
 @Table(
     name = "class_file",
-    uniqueConstraints = @UniqueConstraint(name = "uq_class_file_fqn_sha512", columnNames = {"fqn", "sha512"})
+    uniqueConstraints = @UniqueConstraint(name = "uq_class_file_fqn_sha512", columnNames = {"fqn", "sha512"}),
+    indexes = @jakarta.persistence.Index(name = "idx_class_file_release_count", columnList = "release_count")
 )
 public class ClassFile {
 
@@ -30,6 +31,9 @@ public class ClassFile {
 
     @Column(name = "size_bytes", nullable = false)
     private long sizeBytes;
+
+    @Column(name = "release_count", nullable = false)
+    private long releaseCount = 0;
 
     @JsonIgnore
     @ManyToMany(mappedBy = "classFiles")
@@ -68,6 +72,14 @@ public class ClassFile {
 
     public void setSizeBytes(long sizeBytes) {
         this.sizeBytes = sizeBytes;
+    }
+
+    public long getReleaseCount() {
+        return releaseCount;
+    }
+
+    public void setReleaseCount(long releaseCount) {
+        this.releaseCount = releaseCount;
     }
 
     public List<Release> getReleases() {

--- a/common/src/main/java/de/jd/ecosystems/model/Component.java
+++ b/common/src/main/java/de/jd/ecosystems/model/Component.java
@@ -6,13 +6,17 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import jakarta.persistence.Column;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.List;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "component")
+@Table(
+    name = "component",
+    uniqueConstraints = @UniqueConstraint(name = "uq_component_group_artifact", columnNames = {"groupId", "artifactId"})
+)
 public class Component {
 
     @Id

--- a/common/src/main/java/de/jd/ecosystems/model/Release.java
+++ b/common/src/main/java/de/jd/ecosystems/model/Release.java
@@ -9,6 +9,7 @@ import jakarta.persistence.ManyToMany;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import jakarta.persistence.Column;
 import java.util.List;
 
@@ -17,7 +18,10 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "release")
+@Table(
+    name = "release",
+    uniqueConstraints = @UniqueConstraint(name = "uq_release_component_version", columnNames = {"component_id", "version"})
+)
 public class Release {
 
     @Id

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,8 +1,16 @@
 import { useState } from 'react'
 import { Routes, Route, Link, useNavigate, useParams } from 'react-router-dom'
-import { Search, Home, CheckCircle2, Clock, XCircle, AlertCircle, ChevronRight, FileCode } from 'lucide-react'
+import { Search, Home, CheckCircle2, Clock, XCircle, AlertCircle, ChevronRight, FileCode, Loader2 } from 'lucide-react'
 import { useQuery } from '@tanstack/react-query'
 import { fetchComponents, fetchComponentRedundancy, fetchReleaseDiff, fetchReleasesForClass, fetchTopClasses } from './api'
+
+const formatBytes = (bytes) => {
+    if (!bytes || bytes <= 0) return '0 KB'
+    const kb = bytes / 1024
+    if (kb < 1024) return kb.toFixed(1) + ' KB'
+    const mb = kb / 1024
+    return mb.toFixed(1) + ' MB'
+}
 
 function App() {
     return (
@@ -192,7 +200,14 @@ function ComponentPage() {
     const { data: component, isLoading: compLoading, error: compError } = useQuery({
         queryKey: ['component', groupId, artifactId],
         queryFn: () => fetchComponentRedundancy(groupId, artifactId),
-        refetchInterval: (data) => (data?.status === 'PENDING' ? 3000 : false),
+        refetchInterval: (query) => {
+            const data = query.state.data
+            if (!data) return false
+            if (!data.releases) return 3000           // API returned PENDING string — not a component yet
+            if (data.status === 'PENDING') return 3000
+            if (data.releases?.some(r => r.status === 'PENDING')) return 5000
+            return false
+        },
     })
 
     const { data: diff, isLoading: diffLoading } = useQuery({
@@ -212,6 +227,26 @@ function ComponentPage() {
         </div>
     )
 
+    // API returned a 202 string — component exists but releases haven't been discovered yet
+    if (!component.releases) return (
+        <div className="flex flex-col items-center gap-6 py-24 text-center">
+            <Loader2 className="animate-spin text-blue-500" size={56} />
+            <div className="space-y-2">
+                <p className="text-blue-500 font-mono text-sm">{groupId}</p>
+                <h1 className="text-3xl font-extrabold">{artifactId}</h1>
+            </div>
+            <div className="flex items-center gap-2 text-amber-400 bg-amber-400/10 border border-amber-400/30 rounded-lg px-5 py-3 text-sm">
+                <Loader2 className="animate-spin flex-shrink-0" size={15} />
+                Currently being indexed &mdash; discovering releases, please wait&hellip;
+            </div>
+            <p className="text-slate-500 text-sm">This page will update automatically.</p>
+        </div>
+    )
+
+    const hasPendingReleases = component.releases?.some(r => r.status !== 'READY')
+    const selectedRelease = component.releases?.find(r => r.version === selectedVersion)
+    const selectedIsReady = selectedRelease?.status === 'READY'
+
     return (
         <div className="space-y-8">
             <div className="flex flex-col md:flex-row justify-between items-start gap-6">
@@ -221,6 +256,12 @@ function ComponentPage() {
                     <div className="flex items-center gap-4 text-slate-400">
                         <StatusBadge status={component.status} />
                     </div>
+                    {hasPendingReleases && (
+                        <div className="flex items-center gap-2 text-amber-400 bg-amber-400/10 border border-amber-400/30 rounded-lg px-4 py-2 text-sm mt-2">
+                            <Loader2 className="animate-spin flex-shrink-0" size={15} />
+                            Currently being indexed &mdash; some releases may not yet be available
+                        </div>
+                    )}
                 </div>
             </div>
 
@@ -231,18 +272,40 @@ function ComponentPage() {
                     </h2>
                     <div className="glass-panel overflow-hidden">
                         <div className="max-h-[600px] overflow-y-auto divide-y divide-slate-800">
-                            {component.releases?.map((rel) => (
-                                <button
-                                    key={rel.version}
-                                    onClick={() => setSelectedVersion(rel.version)}
-                                    className={`w-full text-left p-4 hover:bg-slate-900 transition-colors flex items-center justify-between group ${selectedVersion === rel.version ? 'bg-blue-500/10 border-r-2 border-blue-500' : ''}`}
-                                >
-                                    <div>
-                                        <span className="font-bold group-hover:text-blue-400 transition-colors">{rel.version}</span>
-                                    </div>
-                                    <ChevronRight size={16} className={`text-slate-600 group-hover:text-blue-500 transition-all ${selectedVersion === rel.version ? 'translate-x-1' : ''}`} />
-                                </button>
-                            ))}
+                            {[...(component.releases ?? [])].sort((a, b) => (a.status === 'READY' ? -1 : 1) - (b.status === 'READY' ? -1 : 1)).map((rel) => {
+                                const isReady = rel.status === 'READY'
+                                const isSelected = selectedVersion === rel.version
+                                return (
+                                    <button
+                                        key={rel.version}
+                                        onClick={() => setSelectedVersion(rel.version)}
+                                        className={`w-full text-left p-4 transition-colors flex items-center justify-between group ${
+                                            isSelected
+                                                ? isReady
+                                                    ? 'bg-blue-500/10 border-r-2 border-blue-500'
+                                                    : 'bg-amber-500/5 border-r-2 border-amber-500/50'
+                                                : 'hover:bg-slate-900'
+                                        }`}
+                                    >
+                                        <div className="flex flex-col gap-0.5">
+                                            <span className={`font-mono text-sm transition-colors ${
+                                                isReady
+                                                    ? 'font-bold group-hover:text-blue-400'
+                                                    : 'line-through text-slate-500'
+                                            }`}>
+                                                {rel.version}
+                                            </span>
+                                            {!isReady && (
+                                                <span className="text-xs text-amber-500/70">{rel.status}</span>
+                                            )}
+                                        </div>
+                                        {isReady
+                                            ? <ChevronRight size={16} className={`text-slate-600 group-hover:text-blue-500 transition-all ${isSelected ? 'translate-x-1' : ''}`} />
+                                            : <Clock size={14} className="text-amber-500/50 flex-shrink-0" />
+                                        }
+                                    </button>
+                                )
+                            })}
                         </div>
                     </div>
                 </div>
@@ -250,11 +313,28 @@ function ComponentPage() {
                 <div className="lg:col-span-2 space-y-4">
                     <h2 className="text-xl font-bold flex items-center gap-2">
                         <FileCode className="text-blue-500" size={20} /> Release Investigation
+                        {diff?.previousVersion && (
+                            <span className="text-sm font-normal text-slate-500 ml-2">
+                                (Compared against <span className="font-mono text-slate-400">{diff.previousVersion}</span>)
+                            </span>
+                        )}
                     </h2>
 
                     {!selectedVersion ? (
                         <div className="glass-panel p-24 text-center text-slate-500 flex flex-col items-center gap-4">
                             <p>Select a version from the left to investigate changes and redundancy.</p>
+                        </div>
+                    ) : !selectedIsReady ? (
+                        <div className="glass-panel p-16 flex flex-col items-center gap-5 text-center border border-amber-500/20">
+                            <Loader2 className="animate-spin text-amber-400" size={40} />
+                            <div className="space-y-2">
+                                <h3 className="font-bold text-lg">Not yet available</h3>
+                                <p className="text-slate-400 text-sm max-w-xs">
+                                    Release <span className="font-mono text-slate-300">{selectedVersion}</span> is currently being indexed.
+                                    Check back shortly once indexing is complete.
+                                </p>
+                            </div>
+                            <StatusBadge status={selectedRelease?.status} />
                         </div>
                     ) : diffLoading ? (
                         <div className="glass-panel p-24 text-center text-blue-500">
@@ -263,11 +343,46 @@ function ComponentPage() {
                         </div>
                     ) : diff ? (
                         <div className="space-y-6">
-                            <div className="grid grid-cols-3 gap-4">
-                                <MetricCard label="Added" value={diff.added?.length || 0} color="text-green-500" />
-                                <MetricCard label="Modified" value={diff.modified?.length || 0} color="text-yellow-500" />
-                                <MetricCard label="Removed" value={diff.removed?.length || 0} color="text-red-500" />
+                            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
+                                <MetricCard 
+                                    label="Total Classes" 
+                                    value={diff.totalClasses || 0} 
+                                    color="text-blue-500" 
+                                    subValue={formatBytes(diff.totalSizeBytes)}
+                                />
+                                <MetricCard 
+                                    label="Added" 
+                                    value={diff.added?.length || 0} 
+                                    color="text-green-500" 
+                                    quota={diff.totalSizeBytes > 0 ? (diff.addedSizeBytes / diff.totalSizeBytes * 100).toFixed(1) : 0}
+                                    quotaLabel="Addition Quota"
+                                    subValue={formatBytes(diff.addedSizeBytes)}
+                                />
+                                <MetricCard 
+                                    label="Modified" 
+                                    value={diff.modified?.length || 0} 
+                                    color="text-yellow-500" 
+                                    quota={diff.totalSizeBytes > 0 ? (diff.modifiedSizeBytes / diff.totalSizeBytes * 100).toFixed(1) : 0}
+                                    quotaLabel="Modification Quota"
+                                    subValue={formatBytes(diff.modifiedSizeBytes)}
+                                />
+                                <MetricCard 
+                                    label="Unmodified" 
+                                    value={(diff.totalClasses || 0) - (diff.added?.length || 0) - (diff.modified?.length || 0)} 
+                                    color="text-slate-300" 
+                                    quota={diff.totalSizeBytes > 0 ? ((diff.totalSizeBytes - diff.addedSizeBytes - diff.modifiedSizeBytes) / diff.totalSizeBytes * 100).toFixed(1) : 0}
+                                    quotaLabel="Unmodified Quota"
+                                    subValue={formatBytes(diff.totalSizeBytes - diff.addedSizeBytes - diff.modifiedSizeBytes)}
+                                />
+                                <MetricCard 
+                                    label="Removed" 
+                                    value={diff.removed?.length || 0} 
+                                    color="text-red-500" 
+                                    subValue={formatBytes(diff.removedSizeBytes)}
+                                />
                             </div>
+
+                            <QuotaBar diff={diff} />
 
                             <div className="glass-panel p-6 space-y-6">
                                 <DiffSection title="Added Classes" classes={diff.added} color="bg-green-500" />
@@ -305,13 +420,56 @@ function DiffSection({ title, classes, color }) {
     )
 }
 
-function MetricCard({ label, value, color }) {
+function MetricCard({ label, value, color, quota, quotaLabel, subValue }) {
     return (
-        <div className="glass-panel p-4 text-center">
-            <p className="text-slate-500 text-xs uppercase tracking-wider font-semibold mb-1">{label}</p>
+        <div className="glass-panel p-4 text-center group">
+            <p className="text-slate-500 text-[10px] uppercase tracking-wider font-semibold mb-1">{label}</p>
             <p className={`text-3xl font-bold ${color}`}>{value}</p>
+            {subValue && (
+                <p className="text-[10px] text-slate-400 mt-1 font-mono">{subValue}</p>
+            )}
+            {quota !== undefined && (
+                <div className="mt-3 pt-3 border-t border-slate-800/50">
+                    <p className="text-slate-500 text-[9px] uppercase tracking-tight mb-0.5">{quotaLabel}</p>
+                    <p className="text-sm font-mono text-slate-300">{quota}%</p>
+                </div>
+            )}
         </div>
     )
+}
+
+function QuotaBar({ diff }) {
+    if (!diff || !diff.totalSizeBytes) return null;
+
+    const addedPct = (diff.addedSizeBytes / diff.totalSizeBytes) * 100;
+    const modifiedPct = (diff.modifiedSizeBytes / diff.totalSizeBytes) * 100;
+    const unmodifiedPct = 100 - addedPct - modifiedPct;
+
+    return (
+        <div className="w-full h-8 flex rounded-md overflow-hidden bg-slate-900 border border-slate-800 shadow-inner">
+            <div 
+                className="h-full bg-green-500 transition-all duration-500 relative group"
+                style={{ width: `${addedPct}%` }}
+                title={`Added: ${addedPct.toFixed(1)}%`}
+            >
+                {addedPct > 10 && <span className="absolute inset-0 flex items-center justify-center text-[10px] font-bold text-slate-950 uppercase">Added</span>}
+            </div>
+            <div 
+                className="h-full bg-yellow-500 transition-all duration-500 relative group"
+                style={{ width: `${modifiedPct}%` }}
+                title={`Modified: ${modifiedPct.toFixed(1)}%`}
+            >
+                {modifiedPct > 10 && <span className="absolute inset-0 flex items-center justify-center text-[10px] font-bold text-slate-950 uppercase">Modified</span>}
+            </div>
+            <div 
+                className="h-full bg-slate-400 transition-all duration-500 relative group"
+                style={{ width: `${unmodifiedPct}%` }}
+                title={`Unmodified: ${unmodifiedPct.toFixed(1)}%`}
+            >
+                {unmodifiedPct > 10 && <span className="absolute inset-0 flex items-center justify-center text-[10px] font-bold text-slate-950 uppercase">Same</span>}
+            </div>
+        </div>
+    );
 }
 
 function ClassPage() {

--- a/maven-central-redundancy-analyzer/src/main/java/de/jd/ecosystems/analyzer/repository/ClassFileRepository.java
+++ b/maven-central-redundancy-analyzer/src/main/java/de/jd/ecosystems/analyzer/repository/ClassFileRepository.java
@@ -2,6 +2,7 @@ package de.jd.ecosystems.analyzer.repository;
 
 import de.jd.ecosystems.model.ClassFile;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -29,4 +30,8 @@ public interface ClassFileRepository extends JpaRepository<ClassFile, Long> {
     List<ClassFile> findAllByFqnAndSha512Pairs(
             @Param("fqns") String[] fqns,
             @Param("sha512s") String[] sha512s);
+
+    @Modifying
+    @Query("UPDATE ClassFile cf SET cf.releaseCount = cf.releaseCount + 1 WHERE cf IN :classFiles")
+    void incrementReleaseCounts(@Param("classFiles") List<ClassFile> classFiles);
 }

--- a/maven-central-redundancy-analyzer/src/main/java/de/jd/ecosystems/analyzer/repository/ClassFileRepository.java
+++ b/maven-central-redundancy-analyzer/src/main/java/de/jd/ecosystems/analyzer/repository/ClassFileRepository.java
@@ -2,8 +2,31 @@ package de.jd.ecosystems.analyzer.repository;
 
 import de.jd.ecosystems.model.ClassFile;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 import java.util.Optional;
 
 public interface ClassFileRepository extends JpaRepository<ClassFile, Long> {
+
     Optional<ClassFile> findByFqnAndSha512(String fqn, String sha512);
+
+    /**
+     * Fetches all ClassFile rows matching any (fqn, sha512) pair in the provided list.
+     * Uses a native Postgres row-value / VALUES constructor so only ONE round-trip
+     * is needed for the entire JAR instead of one SELECT per class file.
+     *
+     * @param fqns    ordered list of fully-qualified class names
+     * @param sha512s ordered list of SHA-512 hashes (same index = same pair)
+     */
+    @Query(value = """
+            SELECT cf.* FROM class_file cf
+            WHERE (cf.fqn, cf.sha512) IN (
+                SELECT * FROM unnest(:fqns, :sha512s)
+            )
+            """, nativeQuery = true)
+    List<ClassFile> findAllByFqnAndSha512Pairs(
+            @Param("fqns") String[] fqns,
+            @Param("sha512s") String[] sha512s);
 }

--- a/maven-central-redundancy-analyzer/src/main/java/de/jd/ecosystems/analyzer/service/AnalyzerService.java
+++ b/maven-central-redundancy-analyzer/src/main/java/de/jd/ecosystems/analyzer/service/AnalyzerService.java
@@ -99,6 +99,7 @@ public class AnalyzerService {
 
             // --- Step 2: One bulk SELECT for all already-known class files ---
             List<ClassFile> classFiles = batchFindOrCreate(fileInfos);
+            classFileRepository.incrementReleaseCounts(classFiles);
 
             release.setClassFiles(classFiles);
             release.setStatus(ProcessingStatus.READY);

--- a/maven-central-redundancy-analyzer/src/main/java/de/jd/ecosystems/analyzer/service/AnalyzerService.java
+++ b/maven-central-redundancy-analyzer/src/main/java/de/jd/ecosystems/analyzer/service/AnalyzerService.java
@@ -21,8 +21,12 @@ import java.security.NoSuchAlgorithmException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HexFormat;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -82,18 +86,19 @@ public class AnalyzerService {
         try (InputStream jarStream = mavenClient.downloadJar(groupId, artifactId, version);
                 ZipInputStream zipStream = new ZipInputStream(jarStream)) {
 
-            List<ClassFile> classFiles = new ArrayList<>();
+            // --- Step 1: Collect all (fqn -> sha512, size) pairs from the JAR in memory ---
+            // This avoids issuing any DB query inside the hot loop.
+            List<ClassFileInfo> fileInfos = new ArrayList<>();
             ZipEntry entry;
             while ((entry = zipStream.getNextEntry()) != null) {
                 if (!entry.isDirectory() && entry.getName().endsWith(".class")) {
                     byte[] content = zipStream.readAllBytes();
-                    String sha512 = computeSha512(content);
-                    String fqn = entry.getName();
-
-                    ClassFile classFile = findOrCreateClassFile(fqn, sha512);
-                    classFiles.add(classFile);
+                    fileInfos.add(new ClassFileInfo(entry.getName(), computeSha512(content), content.length));
                 }
             }
+
+            // --- Step 2: One bulk SELECT for all already-known class files ---
+            List<ClassFile> classFiles = batchFindOrCreate(fileInfos);
 
             release.setClassFiles(classFiles);
             release.setStatus(ProcessingStatus.READY);
@@ -103,26 +108,67 @@ public class AnalyzerService {
 
         } catch (FileNotFoundException e) {
             System.err.println("Artifact not found: " + groupId + ":" + artifactId + ":" + version);
-            release.setStatus(ProcessingStatus.NOT_FOUND);
-            release.setLastModified(LocalDateTime.now());
-            releaseRepository.save(release);
+            Release rel = releaseOpt.get();
+            rel.setStatus(ProcessingStatus.NOT_FOUND);
+            rel.setLastModified(LocalDateTime.now());
+            releaseRepository.save(rel);
         } catch (Exception e) {
             e.printStackTrace();
-            release.setStatus(ProcessingStatus.FAILED);
-            release.setLastModified(LocalDateTime.now());
-            releaseRepository.save(release);
+            Release rel = releaseOpt.get();
+            rel.setStatus(ProcessingStatus.FAILED);
+            rel.setLastModified(LocalDateTime.now());
+            releaseRepository.save(rel);
         }
     }
 
-    private ClassFile findOrCreateClassFile(String fqn, String sha512) {
-        return classFileRepository.findByFqnAndSha512(fqn, sha512)
-                .orElseGet(() -> {
-                    ClassFile cf = new ClassFile();
-                    cf.setFqn(fqn);
-                    cf.setSha512(sha512);
-                    return classFileRepository.save(cf);
-                });
+    /**
+     * Fetches all already-known ClassFile rows matching the provided (fqn, sha512)
+     * pairs in a SINGLE bulk SELECT, then inserts the genuinely new ones via
+     * saveAll() (which Hibernate batches into groups based on jdbc.batch_size).
+     *
+     * Before this change: N individual SELECTs per JAR (one per .class entry).
+     * After this change: 1 SELECT + at most 1 batched INSERT statement group.
+     */
+    private List<ClassFile> batchFindOrCreate(List<ClassFileInfo> fileInfos) {
+        if (fileInfos.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        String[] fqns = fileInfos.stream().map(ClassFileInfo::fqn).toArray(String[]::new);
+        String[] sha512s = fileInfos.stream().map(ClassFileInfo::sha512).toArray(String[]::new);
+
+        // One bulk SELECT — uses the uq_class_file_fqn_sha512 index
+        List<ClassFile> existing = classFileRepository.findAllByFqnAndSha512Pairs(fqns, sha512s);
+
+        // Build a lookup key so we can detect which entries are already persisted
+        Map<String, ClassFile> existingByKey = existing.stream()
+                .collect(Collectors.toMap(
+                        cf -> cf.getFqn() + "|" + cf.getSha512(),
+                        Function.identity()));
+
+        // Determine genuinely new class files
+        List<ClassFile> toInsert = new ArrayList<>();
+        for (ClassFileInfo info : fileInfos) {
+            String key = info.fqn() + "|" + info.sha512();
+            if (!existingByKey.containsKey(key)) {
+                ClassFile cf = new ClassFile();
+                cf.setFqn(info.fqn());
+                cf.setSha512(info.sha512());
+                cf.setSizeBytes(info.size());
+                toInsert.add(cf);
+            }
+        }
+
+        // Batched INSERT — Hibernate groups these per jdbc.batch_size
+        List<ClassFile> inserted = classFileRepository.saveAll(toInsert);
+
+        // Combine existing + newly inserted for the full result
+        List<ClassFile> all = new ArrayList<>(existing);
+        all.addAll(inserted);
+        return all;
     }
+
+    private record ClassFileInfo(String fqn, String sha512, long size) {}
 
     private String computeSha512(byte[] content) throws NoSuchAlgorithmException {
         MessageDigest digest = MessageDigest.getInstance("SHA-512");

--- a/maven-central-redundancy-analyzer/src/main/resources/application.properties
+++ b/maven-central-redundancy-analyzer/src/main/resources/application.properties
@@ -7,6 +7,9 @@ spring.datasource.username=${DB_USER:postgres}
 spring.datasource.password=${DB_PASS:postgres}
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.properties.hibernate.jdbc.batch_size=50
+spring.jpa.properties.hibernate.order_inserts=true
+spring.jpa.properties.hibernate.order_updates=true
 
 # RabbitMQ Configuration
 spring.rabbitmq.host=${RABBIT_HOST:localhost}

--- a/redundancy-api-service/src/main/java/de/jd/ecosystems/repository/ClassFileRepository.java
+++ b/redundancy-api-service/src/main/java/de/jd/ecosystems/repository/ClassFileRepository.java
@@ -7,6 +7,6 @@ import java.util.Optional;
 public interface ClassFileRepository extends JpaRepository<ClassFile, Long> {
     Optional<ClassFile> findByFqn(String fqn);
 
-    @org.springframework.data.jpa.repository.Query("SELECT cf FROM ClassFile cf ORDER BY size(cf.releases) DESC")
+    @org.springframework.data.jpa.repository.Query("SELECT cf FROM ClassFile cf ORDER BY cf.releaseCount DESC")
     java.util.List<ClassFile> findTop10ByReleaseCount(org.springframework.data.domain.Pageable pageable);
 }

--- a/redundancy-api-service/src/main/java/de/jd/ecosystems/service/RedundancyService.java
+++ b/redundancy-api-service/src/main/java/de/jd/ecosystems/service/RedundancyService.java
@@ -212,16 +212,23 @@ public class RedundancyService {
         diff.setVersion(version);
         diff.setPreviousVersion(previousVersion);
         diff.setTotalClasses(currentRelease.getClassFiles().size());
+        diff.setTotalSizeBytes(currentRelease.getClassFiles().stream().mapToLong(ClassFile::getSizeBytes).sum());
         diff.setAdded(new ArrayList<>());
+        diff.setAddedSizeBytes(0);
         diff.setRemoved(new ArrayList<>());
+        diff.setRemovedSizeBytes(0);
         diff.setModified(new ArrayList<>());
+        diff.setModifiedSizeBytes(0);
 
         Map<String, ClassFile> currentClasses = currentRelease.getClassFiles().stream()
                 .collect(Collectors.toMap(ClassFile::getFqn, cf -> cf));
 
         if (previousRelease == null) {
             // All classes are "added" if it's the first release
-            currentClasses.forEach((fqn, cf) -> diff.getAdded().add(new ClassDiffDTO(cf.getId(), fqn, cf.getSha512())));
+            currentClasses.forEach((fqn, cf) -> {
+                diff.getAdded().add(new ClassDiffDTO(cf.getId(), fqn, cf.getSha512(), cf.getSizeBytes()));
+                diff.setAddedSizeBytes(diff.getAddedSizeBytes() + cf.getSizeBytes());
+            });
         } else {
             Map<String, ClassFile> previousClasses = previousRelease.getClassFiles().stream()
                     .collect(Collectors.toMap(ClassFile::getFqn, cf -> cf));
@@ -229,17 +236,20 @@ public class RedundancyService {
             // Added: In current, not in previous
             currentClasses.forEach((fqn, cf) -> {
                 if (!previousClasses.containsKey(fqn)) {
-                    diff.getAdded().add(new ClassDiffDTO(cf.getId(), fqn, cf.getSha512()));
+                    diff.getAdded().add(new ClassDiffDTO(cf.getId(), fqn, cf.getSha512(), cf.getSizeBytes()));
+                    diff.setAddedSizeBytes(diff.getAddedSizeBytes() + cf.getSizeBytes());
                 } else if (!previousClasses.get(fqn).getSha512().equals(cf.getSha512())) {
                     // Modified: In both, but different hash
-                    diff.getModified().add(new ClassDiffDTO(cf.getId(), fqn, cf.getSha512()));
+                    diff.getModified().add(new ClassDiffDTO(cf.getId(), fqn, cf.getSha512(), cf.getSizeBytes()));
+                    diff.setModifiedSizeBytes(diff.getModifiedSizeBytes() + cf.getSizeBytes());
                 }
             });
 
             // Removed: In previous, not in current
             previousClasses.forEach((fqn, cf) -> {
                 if (!currentClasses.containsKey(fqn)) {
-                    diff.getRemoved().add(new ClassDiffDTO(cf.getId(), fqn, cf.getSha512()));
+                    diff.getRemoved().add(new ClassDiffDTO(cf.getId(), fqn, cf.getSha512(), cf.getSizeBytes()));
+                    diff.setRemovedSizeBytes(diff.getRemovedSizeBytes() + cf.getSizeBytes());
                 }
             });
         }


### PR DESCRIPTION
This PR adds the Size (in Bytes) of indexed class files to the database. This allows new statistics to be shown in the UI. The "Component" view now shows the following information per release:
* Total Number of classes
* Total Class File Size in Bytes
* Added Classes, Added Class File Size in Bytes, Addition Quota
* Modified Classes, Modified Class File Size in Bytes, Modification Quota
* Unmodified Classes, Unmodified Class File Size in Bytes, Unmodified Quota
* Removed Classes, Removed Class File Size in Bytes
* A bar chart that shows the file size quotas

Besides that, there are some usability improvements:
* Usage number of class files is now stored in the DB. This fixes a performance issue with the "Top 10 Most Used Classes" view.
* Add a new loading screen to the "Component" view if the list of releases has not yet been discovered
* If individual releases within the "Component" view are not yet indexed, they are marked as such - additionally a loading icon is shown next to the component name.