### PR TITLE
Add feature for comparing releases to arbitrary baselines

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { Routes, Route, Link, useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import { Search, Home, CheckCircle2, Clock, XCircle, AlertCircle, ChevronRight, FileCode, Loader2 } from 'lucide-react'
 import { useQuery } from '@tanstack/react-query'
-import { fetchComponents, fetchComponentRedundancy, fetchReleaseDiff, fetchReleasesForClass, fetchTopClasses, fetchClassDetails, fetchClassRevisions } from './api'
+import { fetchComponents, fetchComponentRedundancy, fetchReleaseDiff, fetchReleasesForClass, fetchTopClasses, fetchClassDetails, fetchClassRevisions, checkComponentExists } from './api'
 
 const formatBytes = (bytes) => {
     if (!bytes || bytes <= 0) return '0 KB'
@@ -130,19 +130,41 @@ function StatusBadge({ status }) {
 
 function HomePage() {
     const [search, setSearch] = useState('')
+    const [toast, setToast] = useState(null)
+    const [verifying, setVerifying] = useState(false)
     const navigate = useNavigate()
 
     const { data, isLoading, error } = useQuery({
         queryKey: ['components'],
-        queryFn: () => fetchComponents(['PENDING', 'READY']),
+        queryFn: () => fetchComponents(['PENDING', 'READY'], 0, 6, 'lastModified,desc'),
         refetchInterval: 5000,
     })
 
-    const handleSearch = (e) => {
+    const handleSearch = async (e) => {
         e.preventDefault()
-        if (!search.includes(':')) return
-        const [groupId, artifactId] = search.split(':')
-        navigate(`/component/${groupId}/${artifactId}`)
+        const parts = search.split(':')
+        if (parts.length !== 2 || !parts[0].trim() || !parts[1].trim()) {
+            setToast('Input is not a valid component name.')
+            setTimeout(() => setToast(null), 3000)
+            return
+        }
+        const [groupId, artifactId] = parts.map(p => p.trim())
+        
+        setVerifying(true)
+        try {
+            const exists = await checkComponentExists(groupId, artifactId)
+            if (!exists) {
+                setToast('Component does not exist on Maven Central.')
+                setTimeout(() => setToast(null), 3000)
+                return
+            }
+            navigate(`/component/${groupId}/${artifactId}`)
+        } catch (err) {
+            setToast('Error verifying component existence.')
+            setTimeout(() => setToast(null), 3000)
+        } finally {
+            setVerifying(false)
+        }
     }
 
     return (
@@ -153,7 +175,7 @@ function HomePage() {
                     Investigate Redundancy
                 </h1>
                 <p className="text-neutral-400 text-lg">Analyze component releases to identify added, removed, and modified classes across the ecosystem.</p>
-                <form onSubmit={handleSearch} className="flex bg-neutral-900 border border-neutral-800 rounded-full p-2 pl-6 focus-within:ring-2 ring-fuchsia-500/100 transition-all shadow-xl shadow-fuchsia-500/10">
+                <form onSubmit={handleSearch} className="relative flex bg-neutral-900 border border-neutral-800 rounded-full p-2 pl-6 focus-within:ring-2 ring-fuchsia-500/100 transition-all shadow-xl shadow-fuchsia-500/10">
                     <input
                         type="text"
                         placeholder="Search groupId:artifactId..."
@@ -161,9 +183,21 @@ function HomePage() {
                         value={search}
                         onChange={(e) => setSearch(e.target.value)}
                     />
-                    <button type="submit" className="bg-gradient-to-r from-cyan-600 to-cyan-500 hover:from-cyan-500 hover:to-cyan-400 px-8 py-2 rounded-full font-semibold transition-colors">
-                        Analyze
+                    <button type="submit" disabled={verifying} className="bg-gradient-to-r from-cyan-600 to-cyan-500 hover:from-cyan-500 hover:to-cyan-400 px-8 py-2 rounded-full font-semibold transition-colors disabled:opacity-50">
+                        {verifying ? (
+                            <>
+                                <Loader2 size={16} className="animate-spin inline mr-2" />
+                                Verifying...
+                            </>
+                        ) : (
+                            'Analyze'
+                        )}
                     </button>
+                    {toast && (
+                        <div className="absolute top-full left-1/2 -translate-x-1/2 mt-4 bg-red-900/90 border border-red-500/50 text-red-200 px-4 py-2 rounded-lg text-sm whitespace-nowrap z-50 shadow-lg shadow-red-900/20 backdrop-blur-md">
+                            {toast}
+                        </div>
+                    )}
                 </form>
             </section>
 
@@ -263,6 +297,7 @@ function ComponentPage() {
     const { groupId, artifactId } = useParams()
     const [searchParams] = useSearchParams()
     const [selectedVersion, setSelectedVersion] = useState(searchParams.get('version') || null)
+    const [baselineVersion, setBaselineVersion] = useState(null)
 
     const { data: component, isLoading: compLoading, error: compError } = useQuery({
         queryKey: ['component', groupId, artifactId],
@@ -278,8 +313,8 @@ function ComponentPage() {
     })
 
     const { data: diff, isLoading: diffLoading } = useQuery({
-        queryKey: ['diff', groupId, artifactId, selectedVersion],
-        queryFn: () => fetchReleaseDiff(groupId, artifactId, selectedVersion),
+        queryKey: ['diff', groupId, artifactId, selectedVersion, baselineVersion],
+        queryFn: () => fetchReleaseDiff(groupId, artifactId, selectedVersion, baselineVersion),
         enabled: !!selectedVersion,
     })
 
@@ -345,7 +380,10 @@ function ComponentPage() {
                                 return (
                                     <button
                                         key={rel.version}
-                                        onClick={() => setSelectedVersion(rel.version)}
+                                        onClick={() => {
+                                            setSelectedVersion(rel.version)
+                                            setBaselineVersion(null)
+                                        }}
                                         className={`w-full text-left p-4 transition-colors flex items-center justify-between group ${
                                             isSelected
                                                 ? isReady
@@ -378,12 +416,27 @@ function ComponentPage() {
                 </div>
 
                 <div className="lg:col-span-2 space-y-4">
-                    <h2 className="text-xl font-bold flex items-center gap-2">
-                        <FileCode className="text-cyan-500" size={20} /> Release Investigation
-                        {diff?.previousVersion && (
-                            <span className="text-sm font-normal text-neutral-500 ml-2">
-                                (Compared against <span className="font-mono text-neutral-400">{diff.previousVersion}</span>)
-                            </span>
+                    <h2 className="text-xl font-bold flex items-center justify-between w-full">
+                        <div className="flex items-center gap-2">
+                            <FileCode className="text-cyan-500" size={20} /> Release Investigation
+                        </div>
+                        {selectedVersion && selectedIsReady && (
+                            <div className="flex items-center gap-2 text-xs font-normal">
+                                <span className="text-neutral-500">Compare against:</span>
+                                <select 
+                                    value={baselineVersion || diff?.previousVersion || ''}
+                                    onChange={(e) => setBaselineVersion(e.target.value)}
+                                    className="bg-neutral-900 border border-neutral-800 rounded px-2 py-1 text-neutral-300 focus:outline-none focus:ring-1 ring-cyan-500/50"
+                                >
+                                    <option value="">(Auto-detect)</option>
+                                    {(component.releases || [])
+                                        .filter(r => r.status === 'READY' && r.version !== selectedVersion)
+                                        .map(r => (
+                                            <option key={r.version} value={r.version}>{r.version}</option>
+                                        ))
+                                    }
+                                </select>
+                            </div>
                         )}
                     </h2>
 

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -6,10 +6,13 @@ const api = axios.create({
     baseURL: API_BASE_URL,
 })
 
-export const fetchComponents = async (status, page = 0, size = 12) => {
+export const fetchComponents = async (status, page = 0, size = 12, sort = '') => {
     const params = { page, size }
     if (status) {
         params.status = Array.isArray(status) ? status.join(',') : status
+    }
+    if (sort) {
+        params.sort = sort
     }
     const response = await api.get('/components', { params })
     return response.data
@@ -20,8 +23,12 @@ export const fetchComponentRedundancy = async (groupId, artifactId) => {
     return response.data
 }
 
-export const fetchReleaseDiff = async (groupId, artifactId, version) => {
-    const response = await api.get(`/releases/${groupId}/${artifactId}/${version}/diff`)
+export const fetchReleaseDiff = async (groupId, artifactId, version, baseVersion = null) => {
+    const params = {}
+    if (baseVersion) {
+        params.baseVersion = baseVersion
+    }
+    const response = await api.get(`/releases/${groupId}/${artifactId}/${version}/diff`, { params })
     return response.data
 }
 
@@ -43,6 +50,15 @@ export const fetchClassRevisions = async (fqn, page = 0, size = 30, sort = 'rele
 export const fetchTopClasses = async () => {
     const response = await api.get('/top-classes')
     return response.data
+}
+
+export const checkComponentExists = async (groupId, artifactId) => {
+    try {
+        const response = await api.get(`/components/${groupId}/${artifactId}/exists`);
+        return response.data;
+    } catch (e) {
+        return false;
+    }
 }
 
 export default api

--- a/redundancy-api-service/src/main/java/de/jd/ecosystems/controller/RedundancyController.java
+++ b/redundancy-api-service/src/main/java/de/jd/ecosystems/controller/RedundancyController.java
@@ -32,6 +32,13 @@ public class RedundancyController {
         return ResponseEntity.ok(service.getComponents(Optional.ofNullable(status), pageable));
     }
 
+    @GetMapping("/components/{groupId}/{artifactId}/exists")
+    public ResponseEntity<Boolean> checkComponentExists(@PathVariable("groupId") String groupId,
+            @PathVariable("artifactId") String artifactId) {
+        boolean exists = service.checkComponentExistsOnMavenCentral(groupId, artifactId);
+        return ResponseEntity.ok(exists);
+    }
+
     @GetMapping("/top-classes")
     public ResponseEntity<List<de.jd.ecosystems.model.ClassFile>> getTopClasses() {
         return ResponseEntity.ok(service.getTopClassFiles());
@@ -77,8 +84,9 @@ public class RedundancyController {
     @GetMapping("/releases/{groupId}/{artifactId}/{version}/diff")
     public ResponseEntity<ReleaseDiffDTO> getReleaseDiff(@PathVariable("groupId") String groupId,
             @PathVariable("artifactId") String artifactId,
-            @PathVariable("version") String version) {
-        return ResponseEntity.ok(service.getReleaseDiff(groupId, artifactId, version));
+            @PathVariable("version") String version,
+            @RequestParam(required = false) String baseVersion) {
+        return ResponseEntity.ok(service.getReleaseDiff(groupId, artifactId, version, baseVersion));
     }
 
     @GetMapping("/classes/revisions")

--- a/redundancy-api-service/src/main/java/de/jd/ecosystems/service/RedundancyService.java
+++ b/redundancy-api-service/src/main/java/de/jd/ecosystems/service/RedundancyService.java
@@ -205,25 +205,36 @@ public class RedundancyService {
     }
 
     @Transactional(readOnly = true)
-    public ReleaseDiffDTO getReleaseDiff(String groupId, String artifactId, String version) {
+    public ReleaseDiffDTO getReleaseDiff(String groupId, String artifactId, String version, String baseVersion) {
         Component component = componentRepository.findByGroupIdAndArtifactId(groupId, artifactId)
                 .orElseThrow(() -> new IllegalArgumentException("Component not found"));
 
         List<Release> allReleases = releaseRepository.findByComponent(component);
-        List<String> sortedVersions = VersionUtils.sortVersions(
-                allReleases.stream().map(Release::getVersion).collect(Collectors.toList()));
-
-        int currentIndex = sortedVersions.indexOf(version);
-        if (currentIndex < 0) {
-            throw new IllegalArgumentException("Version not found for component");
-        }
-
+        
         Release currentRelease = allReleases.stream()
-                .filter(r -> r.getVersion().equals(version)).findFirst().get();
+                .filter(r -> r.getVersion().equals(version)).findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Target version not found for component"));
 
-        String previousVersion = (currentIndex > 0) ? sortedVersions.get(currentIndex - 1) : null;
-        Release previousRelease = (previousVersion != null) ? allReleases.stream()
-                .filter(r -> r.getVersion().equals(previousVersion)).findFirst().orElse(null) : null;
+        String previousVersion = null;
+        Release previousRelease = null;
+
+        if (baseVersion != null && !baseVersion.isBlank()) {
+            previousRelease = allReleases.stream()
+                    .filter(r -> r.getVersion().equals(baseVersion)).findFirst()
+                    .orElseThrow(() -> new IllegalArgumentException("Baseline version not found for component"));
+            previousVersion = baseVersion;
+        } else {
+            List<String> sortedVersions = VersionUtils.sortVersions(
+                    allReleases.stream().map(Release::getVersion).collect(Collectors.toList()));
+
+            int currentIndex = sortedVersions.indexOf(version);
+            if (currentIndex > 0) {
+                previousVersion = sortedVersions.get(currentIndex - 1);
+                String finalPreviousVersion = previousVersion;
+                previousRelease = allReleases.stream()
+                        .filter(r -> r.getVersion().equals(finalPreviousVersion)).findFirst().orElse(null);
+            }
+        }
 
         ReleaseDiffDTO diff = new ReleaseDiffDTO();
         diff.setVersion(version);
@@ -241,7 +252,7 @@ public class RedundancyService {
                 .collect(Collectors.toMap(ClassFile::getFqn, cf -> cf));
 
         if (previousRelease == null) {
-            // All classes are "added" if it's the first release
+            // All classes are "added" if it's the first release or no baseline found
             currentClasses.forEach((fqn, cf) -> {
                 diff.getAdded().add(new ClassDiffDTO(cf.getId(), fqn, cf.getSha512(), cf.getSizeBytes()));
                 diff.setAddedSizeBytes(diff.getAddedSizeBytes() + cf.getSizeBytes());
@@ -277,6 +288,23 @@ public class RedundancyService {
     private void queueComponentAnalysisTask(String groupId, String artifactId) {
         ComponentAnalysisRequest request = new ComponentAnalysisRequest(groupId, artifactId);
         rabbitTemplate.convertAndSend("maven-central-component-analysis", request);
+    }
+
+    public boolean checkComponentExistsOnMavenCentral(String groupId, String artifactId) {
+        try {
+            String groupPath = groupId.replace('.', '/');
+            String urlString = String.format("https://repo1.maven.org/maven2/%s/%s/maven-metadata.xml", groupPath, artifactId);
+            java.net.URL url = new java.net.URL(urlString);
+            java.net.HttpURLConnection connection = (java.net.HttpURLConnection) url.openConnection();
+            connection.setRequestMethod("HEAD");
+            connection.setConnectTimeout(5000);
+            connection.setReadTimeout(5000);
+            
+            int responseCode = connection.getResponseCode();
+            return responseCode == 200;
+        } catch (Exception e) {
+            return false;
+        }
     }
 
     private void queueReleaseAnalysisTask(String groupId, String artifactId, String version) {


### PR DESCRIPTION
As described in #4, this PR adds a feature that enhances the component view by allowing releases to be compared against any other release baseline.
Some minor improvements:
* Limited number of recently indexed components on home screen to six
* Enforce syntax of <GroupId>:<ArtifactId> when searching for component names - show error on invalid syntax
* Check availability of (syntactically valid) component names on Maven Central before submitting an actual task to the message queue - show error in frontend if component does not exist on Maven Central

Closes #4.